### PR TITLE
Patches for FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-PREFIX=/usr
+PREFIX?=/usr
 INSTALL=install
 
 gen:
 	echo 'generating dissectors/atoms'
-	cd interceptor && (mkdir gen; mkdir gen/RequestDissector; mkdir gen/ReplyDissector; perl _GenerateDissectors.pl && perl _PredefineAtoms.pl)
+	cd interceptor && (mkdir gen; mkdir gen/RequestDissector; mkdir gen/ReplyDissector; perl _GenerateDissectors.pl --prefix=$(PREFIX) && perl _PredefineAtoms.pl)
 
 install: gen
 	echo 'install!'

--- a/interceptor/_GenerateDissectors.pl
+++ b/interceptor/_GenerateDissectors.pl
@@ -7,6 +7,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
+use Getopt::Long qw(GetOptions);
 use XML::Twig;
 use List::Util qw(sum);
 use File::Basename;
@@ -16,18 +17,22 @@ say "reading in XML";
 
 $Data::Dumper::Maxdepth = 2;
 
+my $prefix = "/usr";
+GetOptions("prefix=s" => \$prefix)
+    or die "usage: $0 [--prefix=...]\n";
+
 # TODO: handle all extensions
 my $xproto_xml = XML::Twig->new();
-$xproto_xml->parsefile('/usr/share/xcb/xproto.xml');
+$xproto_xml->parsefile("$prefix/share/xcb/xproto.xml");
 
 my $randr_xml = XML::Twig->new();
-$randr_xml->parsefile('/usr/share/xcb/randr.xml');
+$randr_xml->parsefile("$prefix/share/xcb/randr.xml");
 
 # we replace the <import> nodes with the type elements
 for my $xml ($xproto_xml, $randr_xml) {
     for my $import ($xml->root->get_xpath('import')) {
         my $twig = XML::Twig->new;
-        $twig->parsefile('/usr/share/xcb/' . $import->text . '.xml');
+        $twig->parsefile("$prefix/share/xcb/" . $import->text . '.xml');
         my @d = $twig->root->descendants(qr/(enum|struct)/);
         map { $_->cut } @d;
         $import->replace_with(@d);

--- a/interceptor/interceptor.pl
+++ b/interceptor/interceptor.pl
@@ -18,6 +18,7 @@ use Web;
 use IO::Handle;
 use IO::All;
 use JSON::XS;
+use Getopt::Long qw(GetOptions);
 use v5.10;
 
 #
@@ -72,11 +73,21 @@ sub endpoint_cmdline {
 #    warn "bound to $thishost, port $thisport\n";
 #};
 
+my $server_ip = '127.0.0.1';
+my $server_port = '6000';
+GetOptions("display=s" => sub {
+	       if ($_[1] !~ m{^(.*):(\d+(?:\.\d+)?)$}) {
+		   die "Cannot parse '$_[1]', use something like 127.0.0.1:0\n";
+	       }
+	       $server_ip = $1;
+	       $server_port = 6000 + $2;
+	   })
+    or die "usage: $0 [--display=host:port]\n";
 
 my $conn_id = 0;
 
 # We need to use TCP so that we can do a remote endpoint lookup
-my $tcp_server = tcp_server "127.0.0.1", "6000", sub {
+my $tcp_server = tcp_server $server_ip, $server_port, sub {
     my ($fh, $host, $port) = @_;
 
     my $cmdline = endpoint_cmdline($fh);


### PR DESCRIPTION
Two things:
- make it possible to change PREFIX and add a --prefix option for _GenerateDissectors.pl
- a /proc filesystem does not exist for FreeBSD (that is, there's a procfs which is optional, but it does not has /proc/net/tcp)

Also I added a --display switch for the interceptor.pl, so people can use different displays with --display 127.0.0.1:8
